### PR TITLE
Muon trigger emulation

### DIFF
--- a/interface/BaseAnalyser.h
+++ b/interface/BaseAnalyser.h
@@ -101,6 +101,9 @@ namespace analysis {
 
             /// output tree
             std::shared_ptr<TTree> analyser_tree_;
+            
+            /// emulated triggers
+            std::map<std::string,bool> l1trg_emul_;
 
 
          private:
@@ -193,6 +196,15 @@ namespace analysis {
             void analyserTree();
             /// fill root tree
             void fillAnalyserTree();
+
+            /// emulate l1 trigger
+            virtual bool l1TriggerEmulation(const std::string &, const int &, const float &, const float &, const std::string & );
+            
+            /// return status of all emulated l1 triggers
+            std::map<std::string, bool> l1TriggerEmulated();
+            
+            /// return status of an emulated l1 trigger 
+            bool l1TriggerEmulated(const std::string &);
 
 
       };

--- a/interface/BaseAnalyser.h
+++ b/interface/BaseAnalyser.h
@@ -103,7 +103,7 @@ namespace analysis {
             std::shared_ptr<TTree> analyser_tree_;
             
             /// emulated triggers
-            std::map<std::string,bool> l1trg_emul_;
+            std::map<std::string,bool> trg_emul_;
 
 
          private:
@@ -198,13 +198,13 @@ namespace analysis {
             void fillAnalyserTree();
 
             /// emulate l1 trigger
-            virtual bool l1TriggerEmulation(const std::string &, const int &, const float &, const float &, const std::string & );
+            virtual bool triggerEmulation(const std::string &, const int &, const float &, const float &, const std::string & );
             
             /// return status of all emulated l1 triggers
-            std::map<std::string, bool> l1TriggerEmulated();
+            std::map<std::string, bool> triggersEmulated();
             
             /// return status of an emulated l1 trigger 
-            bool l1TriggerEmulated(const std::string &);
+            bool triggerEmulated(const std::string &);
 
 
       };

--- a/interface/Config.h
+++ b/interface/Config.h
@@ -163,6 +163,12 @@ namespace analysis {
             std::string triggerObjectsPFJets()   const;  
             
             
+            std::string triggerEmulateL1Muons()  const;
+            int triggerEmulateL1MuonsNMin()      const;
+            float triggerEmulateL1MuonsPtMin()   const;
+            float triggerEmulateL1MuonsEtaMax()  const;
+            
+            
          // matching trigger objects
             float triggerMatchL1MuonsDrMax()       const;
             float triggerMatchL3MuonsDrMax()       const;              
@@ -366,6 +372,12 @@ namespace analysis {
             std::string trgObjsL1Jets_;
             std::string trgObjsCaloJets_;
             std::string trgObjsPFJets_;
+            
+         // trigger emulation
+            std::string l1muonemul_;
+            int         l1muonemulnmin_;
+            float       l1muonemulptmin_;
+            float       l1muonemuletamax_;
             
             float matchTrgL1MuonsDrMax_;
             float matchTrgL3MuonsDrMax_;

--- a/interface/Config.h
+++ b/interface/Config.h
@@ -162,12 +162,18 @@ namespace analysis {
             std::string triggerObjectsCaloJets() const;
             std::string triggerObjectsPFJets()   const;  
             
+            /// L1 muon trigger emulation
+            std::string triggerEmulateL1Muons()       const;
+            int         triggerEmulateL1MuonsNMin()   const;
+            float       triggerEmulateL1MuonsPtMin()  const;
+            float       triggerEmulateL1MuonsEtaMax() const;
             
-            std::string triggerEmulateL1Muons()  const;
-            int triggerEmulateL1MuonsNMin()      const;
-            float triggerEmulateL1MuonsPtMin()   const;
-            float triggerEmulateL1MuonsEtaMax()  const;
-            
+            /// L3 muon trigger emulation
+            std::string triggerEmulateL3Muons()       const;
+            int         triggerEmulateL3MuonsNMin()   const;
+            float       triggerEmulateL3MuonsPtMin()  const;
+            float       triggerEmulateL3MuonsEtaMax() const;
+           
             
          // matching trigger objects
             float triggerMatchL1MuonsDrMax()       const;
@@ -373,11 +379,17 @@ namespace analysis {
             std::string trgObjsCaloJets_;
             std::string trgObjsPFJets_;
             
-         // trigger emulation
+         /// L1 muon trigger emulation
             std::string l1muonemul_;
             int         l1muonemulnmin_;
             float       l1muonemulptmin_;
             float       l1muonemuletamax_;
+            
+         /// L3 muon trigger emulation
+            std::string l3muonemul_;
+            int         l3muonemulnmin_;
+            float       l3muonemulptmin_;
+            float       l3muonemuletamax_;
             
             float matchTrgL1MuonsDrMax_;
             float matchTrgL3MuonsDrMax_;

--- a/interface/TriggerAnalyser.h
+++ b/interface/TriggerAnalyser.h
@@ -57,6 +57,7 @@ namespace analysis {
             virtual bool selectionL1();
             
             virtual bool selectionL1Emulated(const bool & , const bool &);
+            virtual bool selectionL3Emulated(const bool & , const bool &);
             
             std::vector< std::shared_ptr<TriggerObject> > triggerObjectsL1Jets();
             std::vector< std::shared_ptr<TriggerObject> > triggerObjectsCaloJets();

--- a/interface/TriggerAnalyser.h
+++ b/interface/TriggerAnalyser.h
@@ -56,6 +56,8 @@ namespace analysis {
             virtual bool selectionHLT();
             virtual bool selectionL1();
             
+            virtual bool selectionL1Emulated(const bool & , const bool &);
+            
             std::vector< std::shared_ptr<TriggerObject> > triggerObjectsL1Jets();
             std::vector< std::shared_ptr<TriggerObject> > triggerObjectsCaloJets();
             std::vector< std::shared_ptr<TriggerObject> > triggerObjectsPFJets();

--- a/interface/TriggerAnalyser.h
+++ b/interface/TriggerAnalyser.h
@@ -56,8 +56,7 @@ namespace analysis {
             virtual bool selectionHLT();
             virtual bool selectionL1();
             
-            virtual bool selectionL1Emulated(const bool & , const bool &);
-            virtual bool selectionL3Emulated(const bool & , const bool &);
+            virtual bool selectionTriggerEmulated(const bool & , const bool &, const std::string& , const int &, const float &, const float &);
             
             std::vector< std::shared_ptr<TriggerObject> > triggerObjectsL1Jets();
             std::vector< std::shared_ptr<TriggerObject> > triggerObjectsCaloJets();

--- a/src/BaseAnalyser.cc
+++ b/src/BaseAnalyser.cc
@@ -406,3 +406,41 @@ void BaseAnalyser::generatorWeight()
    
 }
 
+bool BaseAnalyser::l1TriggerEmulation(const std::string & name, const int & nmin, const float & ptmin, const float & etamax, const std::string & newname)
+{
+   l1trg_emul_[newname] = true;
+   std::shared_ptr< Collection<TriggerObject> > objects = analysis_->collection<TriggerObject>(name);
+   
+   std::vector<TriggerObject> new_objects;
+   
+   
+   for ( int i = 0 ; i < objects->size() ; ++i )
+   {
+      TriggerObject obj = objects->at(i);
+      if ( obj.pt() >= ptmin && fabs(obj.eta()) <= etamax ) 
+      {
+         new_objects.push_back(obj);
+      }
+   }
+   
+   l1trg_emul_[newname] = ( (int)new_objects.size() >= nmin );
+      
+   Collection<TriggerObject> new_collection(new_objects,newname);
+   analysis_->addCollection(new_collection);
+   
+   return l1trg_emul_[newname];
+   
+   
+   
+}
+
+
+std::map<std::string,bool> BaseAnalyser::l1TriggerEmulated()
+{
+   return l1trg_emul_;
+}
+
+bool BaseAnalyser::l1TriggerEmulated(const std::string & name)
+{
+   return l1trg_emul_[name];
+}

--- a/src/BaseAnalyser.cc
+++ b/src/BaseAnalyser.cc
@@ -406,9 +406,9 @@ void BaseAnalyser::generatorWeight()
    
 }
 
-bool BaseAnalyser::l1TriggerEmulation(const std::string & name, const int & nmin, const float & ptmin, const float & etamax, const std::string & newname)
+bool BaseAnalyser::triggerEmulation(const std::string & name, const int & nmin, const float & ptmin, const float & etamax, const std::string & newname)
 {
-   l1trg_emul_[newname] = true;
+   trg_emul_[newname] = true;
    std::shared_ptr< Collection<TriggerObject> > objects = analysis_->collection<TriggerObject>(name);
    
    std::vector<TriggerObject> new_objects;
@@ -423,24 +423,24 @@ bool BaseAnalyser::l1TriggerEmulation(const std::string & name, const int & nmin
       }
    }
    
-   l1trg_emul_[newname] = ( (int)new_objects.size() >= nmin );
+   trg_emul_[newname] = ( (int)new_objects.size() >= nmin );
       
    Collection<TriggerObject> new_collection(new_objects,newname);
    analysis_->addCollection(new_collection);
    
-   return l1trg_emul_[newname];
+   return trg_emul_[newname];
    
    
    
 }
 
 
-std::map<std::string,bool> BaseAnalyser::l1TriggerEmulated()
+std::map<std::string,bool> BaseAnalyser::triggersEmulated()
 {
-   return l1trg_emul_;
+   return trg_emul_;
 }
 
-bool BaseAnalyser::l1TriggerEmulated(const std::string & name)
+bool BaseAnalyser::triggerEmulated(const std::string & name)
 {
-   return l1trg_emul_[name];
+   return trg_emul_[name];
 }

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -124,6 +124,13 @@ Config::Config(int argc, char ** argv) : opt_cmd_("Options"), opt_cfg_("Configur
          ("Trigger.hltPath"              , po::value <std::string>               (&hltPath_)         -> default_value("")                 , "HLT path name")
          ("Trigger.l1Seed"               , po::value <std::string>               (&l1Seed_)          -> default_value("")                 , "L1 seed name")
          ("Trigger.results"              , po::value <std::string>               (&triggerCol_)      -> default_value("TriggerResults")   , "Name of the trigger results collection");
+      
+      // trigger emulation
+      opt_cfg_.add_options()
+         ("Trigger.Emulate.Muons.L1.seed"         , po::value <std::string>               (&l1muonemul_)       -> default_value("")                 , "Name of emulated L1 muon trigger")            
+         ("Trigger.Emulate.Muons.L1.nMin"         , po::value <int>                       (&l1muonemulnmin_)   -> default_value(-1)                 , "Minimum number of emulated L1 muon trigger objects")
+         ("Trigger.Emulate.Muons.L1.ptMin"        , po::value <float>                     (&l1muonemulptmin_)  -> default_value(0)                  , "Minimum pt of emulated L1 muon trigger objects")
+         ("Trigger.Emulate.Muons.L1.etaMax"       , po::value <float>                     (&l1muonemuletamax_) -> default_value(10)                 , "Maximum |eta|s of emulated L1 muon trigger objects");
                                                                                                                                           
       // trigger objects                                                                                                                  
       opt_cfg_.add_options()                                                                                                              
@@ -483,3 +490,11 @@ bool  Config::histogramJetsPerFlavour()  const { return histjets_flavour_ ; }
 
 std::string Config::outputRoot() const { return outputRoot_ ; }
 std::string Config::json() const { return json_ ; }
+
+
+// trigger emulation
+std::string  Config::triggerEmulateL1Muons()       const { return l1muonemul_       ; }
+int         Config::triggerEmulateL1MuonsNMin()   const { return l1muonemulnmin_   ; }
+float       Config::triggerEmulateL1MuonsPtMin()  const { return l1muonemulptmin_  ; }
+float       Config::triggerEmulateL1MuonsEtaMax() const { return l1muonemuletamax_ ; }
+

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -125,12 +125,19 @@ Config::Config(int argc, char ** argv) : opt_cmd_("Options"), opt_cfg_("Configur
          ("Trigger.l1Seed"               , po::value <std::string>               (&l1Seed_)          -> default_value("")                 , "L1 seed name")
          ("Trigger.results"              , po::value <std::string>               (&triggerCol_)      -> default_value("TriggerResults")   , "Name of the trigger results collection");
       
-      // trigger emulation
+      // L1 muontrigger emulation
       opt_cfg_.add_options()
          ("Trigger.Emulate.Muons.L1.seed"         , po::value <std::string>               (&l1muonemul_)       -> default_value("")                 , "Name of emulated L1 muon trigger")            
          ("Trigger.Emulate.Muons.L1.nMin"         , po::value <int>                       (&l1muonemulnmin_)   -> default_value(-1)                 , "Minimum number of emulated L1 muon trigger objects")
          ("Trigger.Emulate.Muons.L1.ptMin"        , po::value <float>                     (&l1muonemulptmin_)  -> default_value(0)                  , "Minimum pt of emulated L1 muon trigger objects")
          ("Trigger.Emulate.Muons.L1.etaMax"       , po::value <float>                     (&l1muonemuletamax_) -> default_value(10)                 , "Maximum |eta|s of emulated L1 muon trigger objects");
+                                                                                                                                          
+      // L3 muontrigger emulation
+      opt_cfg_.add_options()
+         ("Trigger.Emulate.Muons.L3.path"         , po::value <std::string>               (&l3muonemul_)       -> default_value("")                 , "Name of emulated L3 muon trigger")            
+         ("Trigger.Emulate.Muons.L3.nMin"         , po::value <int>                       (&l3muonemulnmin_)   -> default_value(-1)                 , "Minimum number of emulated L3 muon trigger objects")
+         ("Trigger.Emulate.Muons.L3.ptMin"        , po::value <float>                     (&l3muonemulptmin_)  -> default_value(0)                  , "Minimum pt of emulated L3 muon trigger objects")
+         ("Trigger.Emulate.Muons.L3.etaMax"       , po::value <float>                     (&l3muonemuletamax_) -> default_value(10)                 , "Maximum |eta|s of emulated L3 muon trigger objects");
                                                                                                                                           
       // trigger objects                                                                                                                  
       opt_cfg_.add_options()                                                                                                              
@@ -492,9 +499,14 @@ std::string Config::outputRoot() const { return outputRoot_ ; }
 std::string Config::json() const { return json_ ; }
 
 
-// trigger emulation
+// L1 muon trigger emulation
 std::string  Config::triggerEmulateL1Muons()       const { return l1muonemul_       ; }
-int         Config::triggerEmulateL1MuonsNMin()   const { return l1muonemulnmin_   ; }
-float       Config::triggerEmulateL1MuonsPtMin()  const { return l1muonemulptmin_  ; }
-float       Config::triggerEmulateL1MuonsEtaMax() const { return l1muonemuletamax_ ; }
+int          Config::triggerEmulateL1MuonsNMin()   const { return l1muonemulnmin_   ; }
+float        Config::triggerEmulateL1MuonsPtMin()  const { return l1muonemulptmin_  ; }
+float        Config::triggerEmulateL1MuonsEtaMax() const { return l1muonemuletamax_ ; }
 
+// L3 muon trigger emulation
+std::string  Config::triggerEmulateL3Muons()       const { return l3muonemul_       ; }
+int          Config::triggerEmulateL3MuonsNMin()   const { return l3muonemulnmin_   ; }
+float        Config::triggerEmulateL3MuonsPtMin()  const { return l3muonemulptmin_  ; }
+float        Config::triggerEmulateL3MuonsEtaMax() const { return l3muonemuletamax_ ; }

--- a/src/MuonAnalyser.cc
+++ b/src/MuonAnalyser.cc
@@ -55,9 +55,25 @@ bool MuonAnalyser::analysisWithMuons()
    }
    h1_["cutflow"] -> Fill(cutflow_,weight_);
    
+   auto analysis = this->analysis();
+   
+   std::shared_ptr< Collection<TriggerObject> > l1muons = analysis->collection<TriggerObject>(config_->triggerObjectsL1Muons());
    
    if ( config_->triggerObjectsL1Muons() != "" )
-      analysis_->match<Muon,TriggerObject>("Muons",config_->triggerObjectsL1Muons(),config_->triggerMatchL1MuonsDrMax());
+   {
+      std::string triggerObjectsL1Muons = config_->triggerObjectsL1Muons();
+      if ( config_->triggerEmulateL1Muons() != "" &&  config_->triggerEmulateL1MuonsNMin() > 0 )
+      {
+         int nmin = config_->triggerEmulateL1MuonsNMin();
+         float ptmin = config_->triggerEmulateL1MuonsPtMin();
+         float etamax = config_->triggerEmulateL1MuonsEtaMax();
+         std::string newL1Muons = config_->triggerEmulateL1Muons();
+         l1TriggerEmulation(triggerObjectsL1Muons,nmin,ptmin,etamax,newL1Muons);
+         triggerObjectsL1Muons = newL1Muons;
+      }
+      analysis_->match<Muon,TriggerObject>("Muons",triggerObjectsL1Muons,config_->triggerMatchL1MuonsDrMax());
+      
+   }
    if ( config_->triggerObjectsL3Muons() != "" )
       analysis_->match<Muon,TriggerObject>("Muons",config_->triggerObjectsL3Muons(),config_->triggerMatchL3MuonsDrMax());
 

--- a/src/MuonAnalyser.cc
+++ b/src/MuonAnalyser.cc
@@ -59,8 +59,24 @@ bool MuonAnalyser::analysisWithMuons()
          float ptmin = config_->triggerEmulateL1MuonsPtMin();
          float etamax = config_->triggerEmulateL1MuonsEtaMax();
          std::string newL1Muons = config_->triggerEmulateL1Muons();
-         l1TriggerEmulation(triggerObjectsL1Muons,nmin,ptmin,etamax,newL1Muons);
+         triggerEmulation(triggerObjectsL1Muons,nmin,ptmin,etamax,newL1Muons);
          triggerObjectsL1Muons = newL1Muons;
+      }
+   }
+   
+   // L3 muons
+   std::string triggerObjectsL3Muons;
+   if ( config_->triggerObjectsL3Muons() != "" )
+   {
+      triggerObjectsL3Muons = config_->triggerObjectsL3Muons();
+      if ( config_->triggerEmulateL3Muons() != "" &&  config_->triggerEmulateL3MuonsNMin() > 0 )
+      {
+         int nmin = config_->triggerEmulateL3MuonsNMin();
+         float ptmin = config_->triggerEmulateL3MuonsPtMin();
+         float etamax = config_->triggerEmulateL3MuonsEtaMax();
+         std::string newL3Muons = config_->triggerEmulateL3Muons();
+         triggerEmulation(triggerObjectsL3Muons,nmin,ptmin,etamax,newL3Muons);
+         triggerObjectsL3Muons = newL3Muons;
       }
    }
    
@@ -82,7 +98,9 @@ bool MuonAnalyser::analysisWithMuons()
    }
    
    if ( config_->triggerObjectsL3Muons() != "" )
-      analysis_->match<Muon,TriggerObject>("Muons",config_->triggerObjectsL3Muons(),config_->triggerMatchL3MuonsDrMax());
+   {
+      analysis_->match<Muon,TriggerObject>("Muons",triggerObjectsL3Muons,config_->triggerMatchL3MuonsDrMax());
+   }
 
    auto muons = analysis_->collection<Muon>("Muons");
    for ( int j = 0 ; j < muons->size() ; ++j )  muons_.push_back(std::make_shared<Muon>(muons->at(j)));

--- a/src/MuonAnalyser.cc
+++ b/src/MuonAnalyser.cc
@@ -46,22 +46,13 @@ bool MuonAnalyser::analysisWithMuons()
    muons_.clear();
    selectedMuons_.clear();
    onlineMatchedMuons_.clear();
-   if ( ! muonsanalysis_ ) return false;
    
-   ++cutflow_;
-   if ( std::string(h1_["cutflow"] -> GetXaxis()-> GetBinLabel(cutflow_+1)) == "" )
-   {
-      h1_["cutflow"] -> GetXaxis()-> SetBinLabel(cutflow_+1,Form("Using Muon collection: %s",(config_->muonsCollection()).c_str()));
-   }
-   h1_["cutflow"] -> Fill(cutflow_,weight_);
-   
-   auto analysis = this->analysis();
-   
-   std::shared_ptr< Collection<TriggerObject> > l1muons = analysis->collection<TriggerObject>(config_->triggerObjectsL1Muons());
-   
+   // trigger emulation
+   // L1 muons
+   std::string triggerObjectsL1Muons;
    if ( config_->triggerObjectsL1Muons() != "" )
    {
-      std::string triggerObjectsL1Muons = config_->triggerObjectsL1Muons();
+      triggerObjectsL1Muons = config_->triggerObjectsL1Muons();
       if ( config_->triggerEmulateL1Muons() != "" &&  config_->triggerEmulateL1MuonsNMin() > 0 )
       {
          int nmin = config_->triggerEmulateL1MuonsNMin();
@@ -71,9 +62,25 @@ bool MuonAnalyser::analysisWithMuons()
          l1TriggerEmulation(triggerObjectsL1Muons,nmin,ptmin,etamax,newL1Muons);
          triggerObjectsL1Muons = newL1Muons;
       }
+   }
+   
+   
+   if ( ! muonsanalysis_ ) return false;
+   
+   ++cutflow_;
+   if ( std::string(h1_["cutflow"] -> GetXaxis()-> GetBinLabel(cutflow_+1)) == "" )
+   {
+      h1_["cutflow"] -> GetXaxis()-> SetBinLabel(cutflow_+1,Form("Using Muon collection: %s",(config_->muonsCollection()).c_str()));
+   }
+   h1_["cutflow"] -> Fill(cutflow_,weight_);
+   
+   
+   if ( config_->triggerObjectsL1Muons() != "" )
+   {
       analysis_->match<Muon,TriggerObject>("Muons",triggerObjectsL1Muons,config_->triggerMatchL1MuonsDrMax());
       
    }
+   
    if ( config_->triggerObjectsL3Muons() != "" )
       analysis_->match<Muon,TriggerObject>("Muons",config_->triggerObjectsL3Muons(),config_->triggerMatchL3MuonsDrMax());
 

--- a/src/TriggerAnalyser.cc
+++ b/src/TriggerAnalyser.cc
@@ -61,8 +61,9 @@ bool TriggerAnalyser::selectionTrigger() // Maybe not use this, use selectionHLT
    bool hlt = selectionHLT();
    bool l1  = selectionL1();
    bool l1emul = selectionL1Emulated(l1,hlt);
+   bool l3emul = selectionL3Emulated(l1,hlt);
    
-   return (hlt && l1 && l1emul);
+   return (hlt && l1 && l1emul && l3emul);
    
 }
 
@@ -112,7 +113,32 @@ bool TriggerAnalyser::selectionL1Emulated(const bool & l1, const bool & hlt)
    
    
    if ( ! ( l1 && hlt ) ) return false;
-   if ( ! l1TriggerEmulated(name) ) return false;
+   if ( ! triggerEmulated(name) ) return false;
+   
+   h1_["cutflow"] -> Fill(cutflow_,weight_);
+
+   
+   return true;
+}
+
+
+bool TriggerAnalyser::selectionL3Emulated(const bool & l1, const bool & hlt)
+{
+   if (! ( config_->triggerEmulateL3Muons() != "" &&  config_->triggerEmulateL3MuonsNMin() > 0 )) return true;
+   
+   ++cutflow_;
+   
+   std::string name = config_->triggerEmulateL3Muons();
+   int nmin = config_->triggerEmulateL3MuonsNMin();
+   float ptmin = config_->triggerEmulateL3MuonsPtMin();
+   float etamax = config_->triggerEmulateL3MuonsEtaMax();
+   
+   if ( std::string(h1_["cutflow"] -> GetXaxis()-> GetBinLabel(cutflow_+1)) == "" ) 
+      h1_["cutflow"] -> GetXaxis()-> SetBinLabel(cutflow_+1,Form("%s (emulated: n >= %d, pT >= %4.1f GeV, |eta| <= %4.1f)",name.c_str(),nmin,ptmin,etamax));
+   
+   
+   if ( ! ( l1 && hlt ) ) return false;
+   if ( ! triggerEmulated(name) ) return false;
    
    h1_["cutflow"] -> Fill(cutflow_,weight_);
 

--- a/src/TriggerAnalyser.cc
+++ b/src/TriggerAnalyser.cc
@@ -60,8 +60,9 @@ bool TriggerAnalyser::selectionTrigger() // Maybe not use this, use selectionHLT
 {
    bool hlt = selectionHLT();
    bool l1  = selectionL1();
+   bool l1emul = selectionL1Emulated(l1,hlt);
    
-   return (hlt && l1);
+   return (hlt && l1 && l1emul);
    
 }
 
@@ -94,6 +95,31 @@ bool TriggerAnalyser::selectionL1()
 
    return true;
 }
+
+bool TriggerAnalyser::selectionL1Emulated(const bool & l1, const bool & hlt)
+{
+   if (! ( config_->triggerEmulateL1Muons() != "" &&  config_->triggerEmulateL1MuonsNMin() > 0 )) return true;
+   
+   ++cutflow_;
+   
+   std::string name = config_->triggerEmulateL1Muons();
+   int nmin = config_->triggerEmulateL1MuonsNMin();
+   float ptmin = config_->triggerEmulateL1MuonsPtMin();
+   float etamax = config_->triggerEmulateL1MuonsEtaMax();
+   
+   if ( std::string(h1_["cutflow"] -> GetXaxis()-> GetBinLabel(cutflow_+1)) == "" ) 
+      h1_["cutflow"] -> GetXaxis()-> SetBinLabel(cutflow_+1,Form("%s (emulated: n >= %d, pT >= %4.1f GeV, |eta| <= %4.1f)",name.c_str(),nmin,ptmin,etamax));
+   
+   
+   if ( ! ( l1 && hlt ) ) return false;
+   if ( ! l1TriggerEmulated(name) ) return false;
+   
+   h1_["cutflow"] -> Fill(cutflow_,weight_);
+
+   
+   return true;
+}
+
 
 
 bool TriggerAnalyser::analysisWithTrigger()

--- a/src/TriggerAnalyser.cc
+++ b/src/TriggerAnalyser.cc
@@ -60,10 +60,30 @@ bool TriggerAnalyser::selectionTrigger() // Maybe not use this, use selectionHLT
 {
    bool hlt = selectionHLT();
    bool l1  = selectionL1();
-   bool l1emul = selectionL1Emulated(l1,hlt);
-   bool l3emul = selectionL3Emulated(l1,hlt);
    
-   return (hlt && l1 && l1emul && l3emul);
+   /// Emulated triggers
+   // L1 muon trigger
+   bool l1muon = true;
+   if ( config_->triggerEmulateL1Muons() != "" &&  config_->triggerEmulateL1MuonsNMin() > 0 && config_->triggerObjectsL1Muons() != "" )
+   {
+      int nmin = config_->triggerEmulateL1MuonsNMin();
+      float ptmin = config_->triggerEmulateL1MuonsPtMin();
+      float etamax = config_->triggerEmulateL1MuonsEtaMax();
+      l1muon = selectionTriggerEmulated(l1,hlt,config_->triggerEmulateL1Muons(),nmin,ptmin,etamax);
+   }
+   // L3 muon trigger
+   bool l3muon = true;
+   if ( config_->triggerEmulateL3Muons() != "" &&  config_->triggerEmulateL3MuonsNMin() > 0  && config_->triggerObjectsL3Muons() != "" )
+   {
+      int nmin = config_->triggerEmulateL3MuonsNMin();
+      float ptmin = config_->triggerEmulateL3MuonsPtMin();
+      float etamax = config_->triggerEmulateL3MuonsEtaMax();
+      l3muon = selectionTriggerEmulated(l1,hlt,config_->triggerEmulateL3Muons(),nmin,ptmin,etamax);
+   }
+   
+   bool emul = l1muon && l3muon;
+   
+   return (hlt && l1 && emul);
    
 }
 
@@ -97,19 +117,13 @@ bool TriggerAnalyser::selectionL1()
    return true;
 }
 
-bool TriggerAnalyser::selectionL1Emulated(const bool & l1, const bool & hlt)
+bool TriggerAnalyser::selectionTriggerEmulated(const bool & l1, const bool & hlt, const std::string & name, const int & nmin, const float & ptmin, const float & etamax)
 {
-   if (! ( config_->triggerEmulateL1Muons() != "" &&  config_->triggerEmulateL1MuonsNMin() > 0 )) return true;
    
    ++cutflow_;
    
-   std::string name = config_->triggerEmulateL1Muons();
-   int nmin = config_->triggerEmulateL1MuonsNMin();
-   float ptmin = config_->triggerEmulateL1MuonsPtMin();
-   float etamax = config_->triggerEmulateL1MuonsEtaMax();
-   
    if ( std::string(h1_["cutflow"] -> GetXaxis()-> GetBinLabel(cutflow_+1)) == "" ) 
-      h1_["cutflow"] -> GetXaxis()-> SetBinLabel(cutflow_+1,Form("%s (emulated: n >= %d, pT >= %4.1f GeV, |eta| <= %4.1f)",name.c_str(),nmin,ptmin,etamax));
+      h1_["cutflow"] -> GetXaxis()-> SetBinLabel(cutflow_+1,Form("Emulated: %s (n >= %d, pT >= %4.1f GeV, |eta| <= %4.1f)",name.c_str(),nmin,ptmin,etamax));
    
    
    if ( ! ( l1 && hlt ) ) return false;
@@ -121,30 +135,6 @@ bool TriggerAnalyser::selectionL1Emulated(const bool & l1, const bool & hlt)
    return true;
 }
 
-
-bool TriggerAnalyser::selectionL3Emulated(const bool & l1, const bool & hlt)
-{
-   if (! ( config_->triggerEmulateL3Muons() != "" &&  config_->triggerEmulateL3MuonsNMin() > 0 )) return true;
-   
-   ++cutflow_;
-   
-   std::string name = config_->triggerEmulateL3Muons();
-   int nmin = config_->triggerEmulateL3MuonsNMin();
-   float ptmin = config_->triggerEmulateL3MuonsPtMin();
-   float etamax = config_->triggerEmulateL3MuonsEtaMax();
-   
-   if ( std::string(h1_["cutflow"] -> GetXaxis()-> GetBinLabel(cutflow_+1)) == "" ) 
-      h1_["cutflow"] -> GetXaxis()-> SetBinLabel(cutflow_+1,Form("%s (emulated: n >= %d, pT >= %4.1f GeV, |eta| <= %4.1f)",name.c_str(),nmin,ptmin,etamax));
-   
-   
-   if ( ! ( l1 && hlt ) ) return false;
-   if ( ! triggerEmulated(name) ) return false;
-   
-   h1_["cutflow"] -> Fill(cutflow_,weight_);
-
-   
-   return true;
-}
 
 
 


### PR DESCRIPTION
New features to emulate muon triggers given the L1 and L3 trigger objects.
Set via config file, e.g. MSSM Hbb Run2 2027 semileptonic uses a Mu12 eta2p3 trigger both at L1 and L3, but the trigger available is in the menu is HLT_Mu8 for trigger efficiency studies:
```
[Trigger.Emulate.Muons.L1]
seed = L1_SingleMu12Eta2p3
nMin = 1
ptMin = 12
etaMax = 2.3

[Trigger.Emulate.Muons.L3]
path = HLT_L3SingleMu12Eta2p3
nMin = 1
ptMin = 12
etaMax = 2.3
```
ℹ️  To use this feature you must use the following method for the trigger selection in your macro :
```c++
if ( ! analyser.selectionTrigger()        )   continue;
```
⚠️   **REMOVE** any direct calls to HLT and L1 selections, namely the lines  ⚠️ 
```c++
if ( ! analyser.selectionL1 ()           )   continue;
if ( ! analyser.selectionHLT()           )   continue;
```