### PR TITLE
Online btag SF fix

### DIFF
--- a/interface/BaseAnalyser.h
+++ b/interface/BaseAnalyser.h
@@ -117,6 +117,9 @@ namespace analysis {
             std::map<std::string, std::vector<float> > scale_data_;
             float scale_correction_;
 
+            /// is muon analysis
+            bool is_mouns_analysis_;
+
          private :
 
             /// name of the executable
@@ -146,6 +149,11 @@ namespace analysis {
             void cutflow(const int &);
             /// create and update cutflow entry in the cutflow histogram 
             void cutflow(const std::string & label, const bool & ok = true);
+
+            /// get is muons analysis
+            bool isMuonsAnalysis();
+            /// get is muons analysis
+            void isMuonsAnalysis(const bool &);
 
             // Actions
             /// event entry to be readout and processed

--- a/src/Analyser.cc
+++ b/src/Analyser.cc
@@ -26,6 +26,7 @@ Analyser::Analyser(int argc, char * argv[]) : BaseAnalyser(argc,argv),  // not s
                                               JetAnalyser(argc,argv),
                                               MuonAnalyser(argc,argv)
 {
+   this->isMuonsAnalysis(muonsanalysis_);
 }
 
 Analyser::~Analyser()

--- a/src/BaseAnalyser.cc
+++ b/src/BaseAnalyser.cc
@@ -618,3 +618,14 @@ void BaseAnalyser::actionApplyScaleCorrection(const std::string &title)
    }
    cutflow(label);
 }
+
+/// get is muons analysis
+bool BaseAnalyser::isMuonsAnalysis()
+{
+   return is_mouns_analysis_;
+}
+/// get is muons analysis
+void BaseAnalyser::isMuonsAnalysis(const bool & is_muon_analysis)
+{
+   is_mouns_analysis_ = is_muon_analysis;
+}

--- a/src/JetAnalyser.cc
+++ b/src/JetAnalyser.cc
@@ -1950,8 +1950,15 @@ void JetAnalyser::actionApplyBtagOnlineSF(const std::vector<int> & ranks)
    std::string bnobsf_muonjet = basename(config_->onlinebtagSF());
    if ( config_->onlinebtagMuonJetSF() != "" ) label = Form("%s, %s",label.c_str(), bnobsf_muonjet.c_str());
 
-   sf1 = this->getBtagOnlineSF(matched_ranks[0],selectedJets_[matched_ranks[0]]->muon()!=0);
-   sf2 = this->getBtagOnlineSF(matched_ranks[1],selectedJets_[matched_ranks[1]]->muon()!=0);
+   bool muonjet1 = false;
+   bool muonjet2 = false;
+   if ( !config_->muonsVeto() && this->isMuonsAnalysis() ) 
+   {
+      if ( selectedJets_[matched_ranks[0]]->muon() ) muonjet1 = true;
+      if ( selectedJets_[matched_ranks[1]]->muon() ) muonjet2 = true;
+   }
+   sf1 = this->getBtagOnlineSF(matched_ranks[0],muonjet1);
+   sf2 = this->getBtagOnlineSF(matched_ranks[1],muonjet2);
 
    weight_ *= (sf1*sf2);
    cutflow(label);
@@ -1970,7 +1977,9 @@ float JetAnalyser::getBtagOnlineSF(const int & r,const bool & muonjet)
 
    sf = btag_trigger_efficiency_->findSF(selectedJets_[j]->pt(), config_->onlinebtagSystematics());
    if ( config_->onlinebtagMuonJetSF() != "" && muonjet )
+   {
       sf = btag_muonjet_trigger_efficiency_->findSF(selectedJets_[j]->pt(), config_->onlinebtagSystematics());
+   }
    
    return sf;
 }


### PR DESCRIPTION
fix bug when accessing muon information in jets
explicit differentiation from SL and FH with muon veto to avoid using muon-jet SF when running the muon veto