### PR TITLE
offline btag SF systematics types

### DIFF
--- a/bin/AnalysisJetsExample.cc
+++ b/bin/AnalysisJetsExample.cc
@@ -87,8 +87,8 @@ int main(int argc, char * argv[])
          
          // b-tag scale factors central, up and down
          double jet_bscalefactor     = jet.btagSF(bsf_reader); // OR jet.btagSF(analysis.btagCalibration()); 
-         double jet_bscalefactorup   = jet.btagSFup(bsf_reader,2); 
-         double jet_bscalefactordown = jet.btagSFdown(bsf_reader,2); 
+         double jet_bscalefactorup   = jet.btagSFup(bsf_reader,"", 2); 
+         double jet_bscalefactordown = jet.btagSFdown(bsf_reader,"", 2); 
          
       // JER 
          jet.jerInfo(*jerinfo,0.2); // this also performs matching to the added gen jets above, with delta R < 0.2 which is default and can be omitted

--- a/interface/Analysis.h
+++ b/interface/Analysis.h
@@ -174,7 +174,7 @@ namespace analysis {
                                  const std::string & filename,
                                  const std::string & wp,
                                  const std::string & sysType="central",
-                                 const std::vector<std::string> & otherSysTypes={"up", "down"});
+                                 const std::vector<std::string> & otherSysTypes={"up","down","up_correlated","down_correlated","up_uncorrelated","down_uncorrelated"});
             
             
             std::shared_ptr<BTagCalibrationReader> btagCalibration();

--- a/interface/Config.h
+++ b/interface/Config.h
@@ -134,6 +134,7 @@ namespace analysis {
             std::string btagAlgorithm() const;
             std::string btagScaleFactors() const;
             int         btagSystematics() const;
+            std::string btagSystematicsType() const;
             std::vector<std::string> jetsBtagWP() const;
             std::vector<float> jetsBtagProbB() const;
             std::vector<float> jetsBtagProbBB() const;
@@ -469,6 +470,7 @@ namespace analysis {
             std::string btagalgo_;
             std::string btagsf_;
             int btagsf_syst_;
+            std::string btagsf_syst_type_;
             //
             std::string scale_file_;
             std::string scale_par_;

--- a/interface/Jet.h
+++ b/interface/Jet.h
@@ -143,8 +143,8 @@ namespace analysis {
             
             /// btag SF
             double btagSF    (std::shared_ptr<BTagCalibrationReader> reader, const std::string & flavalgo = "Hadron") const;
-            double btagSFup  (std::shared_ptr<BTagCalibrationReader> reader, const float & nsig = 1, const std::string & flavalgo = "Hadron") const;
-            double btagSFdown(std::shared_ptr<BTagCalibrationReader> reader, const float & nsig = 1, const std::string & flavalgo = "Hadron") const;
+            double btagSFup  (std::shared_ptr<BTagCalibrationReader> reader, const std::string & type = "", const float & nsig = 1, const std::string & flavalgo = "Hadron") const;
+            double btagSFdown(std::shared_ptr<BTagCalibrationReader> reader, const std::string & type = "", const float & nsig = 1, const std::string & flavalgo = "Hadron") const;
             double btagSFsys (std::shared_ptr<BTagCalibrationReader> reader, const std::string & systype  = "central", const std::string & flavalgo = "Hadron") const;
             
             /// pointer to the FSR jet

--- a/interface/JetAnalyser.h
+++ b/interface/JetAnalyser.h
@@ -124,7 +124,7 @@ namespace analysis {
             virtual bool selectionBJetProbC(const int &);
             virtual bool selectionBJetProbG(const int &);
             virtual bool selectionBJetProbLight(const int &);
-            virtual ScaleFactors btagSF(const int &, const std::string &);
+            virtual ScaleFactors btagSF(const int &, const std::string &, const std::string &);
             virtual bool selectionNonBJet(const int &);
             virtual bool onlineJetMatching(const int &);
             /// returns true if jet match to online b object for the given jet rank 

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -54,6 +54,7 @@ Config::Config(int argc, char ** argv) : opt_cmd_("Options"), opt_cfg_("Configur
          ("jetsf",po::value <int>(&onljetsyst_),"Online jet scale factor systematic variation (sigma)")  
          ("onlbtagsf",po::value <int>(&onlbtagsyst_),"Online btag scale factor systematic variation (sigma)")
          ("btagsyst",po::value <int>(&btagsf_syst_),"Offline btag scale factor systematic variation (sigma)")
+         ("btagsyst_type",po::value <std::string>(&btagsf_syst_type_)-> default_value(""),"Offline btag scale factor systematic variation type")
          ("pileup",po::value <int>(&puweightsyst_),"Pileup weight systematic variation (sigma)")  
          ("muonID",po::value <int>(&muonIDweightsyst_),"Muon ID weight systematic variation (sigma)")  
          ("btagweight",po::bool_switch(&cmdl_bweight_),"Apply btag weight defined in the config file")  

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -101,6 +101,7 @@ Config::Config(int argc, char ** argv) : opt_cmd_("Options"), opt_cfg_("Configur
          ("Corrections.BTag.onlinebtagMuonJetSF" , po::value <std::string>       (&onlbtagsf_muonjet_)       -> default_value("")                 , "Online btag SF file")
          ("Corrections.BTag.SF"          , po::value <std::string>               (&btagsf_)          -> default_value("")                 , "b-tagging scale factor in CSV format")
          ("Corrections.BTag.offlineSystematics", po::value <int>                 (&btagsf_syst_)     -> default_value(0)                  , "b-tagging scale factor systematic variation (sigma), default = 0")
+         ("Corrections.BTag.offlineSystematicsType", po::value <std::string>     (&btagsf_syst_type_)-> default_value("")                 , "b-tagging scale factor systematic variation type: empty (sum), correlated, uncorrelated, default = empty")
          ("Corrections.BTag.Efficiencies1", po::value <std::string>              (&btageff_[0])      -> default_value("")                 , "b-tagging efficiencies in root file")
          ("Corrections.BTag.Efficiencies2", po::value <std::string>              (&btageff_[1])      -> default_value("")                 , "b-tagging efficiencies in root file")
          ("Corrections.BTag.Efficiencies3", po::value <std::string>              (&btageff_[2])      -> default_value("")                 , "b-tagging efficiencies in root file")
@@ -570,6 +571,7 @@ std::string        Config::l1tJetsCollection()  const { return l1tjetsCol_; }
 std::string        Config::btagAlgorithm()      const { return btagalgo_; }
 std::string        Config::btagScaleFactors()   const { return btagsf_; }
 int                Config::btagSystematics()    const { return btagsf_syst_; }
+std::string        Config::btagSystematicsType() const { return btagsf_syst_type_; }
 std::string        Config::onlinemuonSF()        const { return onlmuonsf_; }
 int                Config::onlinemuonSystematics() const { return onlmuonsyst_; }
 std::vector<std::string> Config::jetsBtagWP()   const { return jetsbtagwp_; }

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -54,7 +54,7 @@ Config::Config(int argc, char ** argv) : opt_cmd_("Options"), opt_cfg_("Configur
          ("jetsf",po::value <int>(&onljetsyst_),"Online jet scale factor systematic variation (sigma)")  
          ("onlbtagsf",po::value <int>(&onlbtagsyst_),"Online btag scale factor systematic variation (sigma)")
          ("btagsyst",po::value <int>(&btagsf_syst_),"Offline btag scale factor systematic variation (sigma)")
-         ("btagsyst_type",po::value <std::string>(&btagsf_syst_type_)-> default_value(""),"Offline btag scale factor systematic variation type")
+         ("btagsyst_type",po::value <std::string>(&btagsf_syst_type_),"Offline btag scale factor systematic variation type")
          ("pileup",po::value <int>(&puweightsyst_),"Pileup weight systematic variation (sigma)")  
          ("muonID",po::value <int>(&muonIDweightsyst_),"Muon ID weight systematic variation (sigma)")  
          ("btagweight",po::bool_switch(&cmdl_bweight_),"Apply btag weight defined in the config file")  

--- a/src/Jet.cc
+++ b/src/Jet.cc
@@ -297,19 +297,25 @@ double Jet::btagSF(std::shared_ptr<BTagCalibrationReader> reader, const std::str
 {
    return this -> btagSFsys(reader,"central",flavalgo);
 }
-double Jet::btagSFup(std::shared_ptr<BTagCalibrationReader> reader, const float & nsig, const std::string & flavalgo) const
+double Jet::btagSFup(std::shared_ptr<BTagCalibrationReader> reader, const std::string & type, const float & nsig, const std::string & flavalgo) const
 {
+   std::string suffix = "";
+   if ( type != "" ) suffix = "_"+type;
+   std::string systype = "up"+suffix;
    double sf   = this -> btagSFsys(reader,"central",flavalgo);
-   double sfup = this -> btagSFsys(reader,"up",flavalgo);
+   double sfup = this -> btagSFsys(reader,systype,flavalgo);
    double sig1 = fabs(sfup - sf);
    sfup = sf+(nsig*sig1);
    
    return sfup;
 }
-double Jet::btagSFdown(std::shared_ptr<BTagCalibrationReader> reader, const float & nsig, const std::string & flavalgo) const
+double Jet::btagSFdown(std::shared_ptr<BTagCalibrationReader> reader, const std::string & type, const float & nsig, const std::string & flavalgo) const
 {
+   std::string suffix = "";
+   if ( type != "" ) suffix = "_"+type;
+   std::string systype = "down"+suffix; 
    double sf     = this -> btagSFsys(reader,"central",flavalgo);
-   double sfdown = this -> btagSFsys(reader,"down",flavalgo);
+   double sfdown = this -> btagSFsys(reader,systype,flavalgo);
    double sig1 = fabs(sfdown - sf);
    sfdown = sf-(nsig*sig1);
    


### PR DESCRIPTION
Additional correlated and uncorrelated uncertainties types, namely correlated and uncorrelated.
The default is still the old type.
The correlated/uncorrelated types can be given either in the configuration file, e.g., a 1 sigma down variation of uncorrelated uncertainties (be reminded that the sign of the number of standard deviations defines whether up(+) or down(-)
```
[Corrections.BTag]
...
offlineSystematics = -1
offlineSystematicsType = uncorrelated
...
```
or via the command line, e.g 1 sigma up variation of correlated uncertainties (command line overrides the configuration file)
```
MssmHbbAnalysis -c mssmhbb_fh_2018ul.cfg --btagsyst=-5 --btagsyst_type=correlated
```
